### PR TITLE
Validate required metrics columns and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
 plotly
+pytest

--- a/src/data_handler.py
+++ b/src/data_handler.py
@@ -1,0 +1,38 @@
+"""Data handling utilities for metric loading."""
+
+from __future__ import annotations
+
+from typing import List
+import pandas as pd
+
+REQUIRED_COLUMNS: List[str] = [
+    "Expectativa_Pontos",
+    "Fator_Lucro_MME",
+    "Taxa_Acerto",
+    "N_Trades",
+    "ATR14_Medio",
+    "OR10_Medio",
+    "Drawdown_Medio",
+    "Fechamento_Ant_Medio",
+    "Ticker",
+    "Dia_Semana",
+]
+
+
+def load_metrics(csv_path: str) -> pd.DataFrame:
+    """Load metrics from a CSV file ensuring required columns are present.
+
+    Args:
+        csv_path: Path to the metrics CSV file.
+
+    Returns:
+        DataFrame containing the metrics.
+
+    Raises:
+        ValueError: If any required columns are missing from the file.
+    """
+    df = pd.read_csv(csv_path)
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns in metrics file: {', '.join(missing)}")
+    return df

--- a/tests/test_data_handler.py
+++ b/tests/test_data_handler.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from src.data_handler import load_metrics
+
+
+def test_load_metrics_missing_columns(tmp_path):
+    data = {
+        "Expectativa_Pontos": [1],
+        "Fator_Lucro_MME": [1],
+        "Taxa_Acerto": [1],
+        "N_Trades": [1],
+        "ATR14_Medio": [1],
+        # Missing OR10_Medio
+        "Drawdown_Medio": [1],
+        "Fechamento_Ant_Medio": [1],
+        "Ticker": ["ABC"],
+        # Missing Dia_Semana
+    }
+    df = pd.DataFrame(data)
+    csv_file = tmp_path / "metrics.csv"
+    df.to_csv(csv_file, index=False)
+
+    with pytest.raises(ValueError) as exc_info:
+        load_metrics(str(csv_file))
+
+    message = str(exc_info.value)
+    assert "OR10_Medio" in message
+    assert "Dia_Semana" in message


### PR DESCRIPTION
## Summary
- validate that metrics CSVs contain all expected columns when loading
- test that missing required columns raise a helpful ValueError
- add pytest to requirements for running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd7e4fe4083208157cbf648488625